### PR TITLE
[Go] Add HLL accuracy bounds and merge accuracy characterization profiles

### DIFF
--- a/go/configs.go
+++ b/go/configs.go
@@ -38,6 +38,8 @@ type distinctCountJobConfigType struct {
 
 var (
 	distinctCountJobConfig = distinctCountJobConfigType{
+		lgK: 4,
+
 		lgMinU: 0,
 		lgMaxU: 20,
 		UPPO:   16,

--- a/go/configs.go
+++ b/go/configs.go
@@ -51,6 +51,20 @@ var (
 		lgQK:      12,
 		interData: true,
 	}
+	distinctCountBoundsJobConfig = distinctCountJobConfigType{
+		lgK: 4,
+
+		lgMinU: 0,
+		lgMaxU: 20,
+		UPPO:   16,
+
+		lgMinT: 10,
+		lgMaxT: 20,
+		TPPO:   1,
+
+		lgQK:      12,
+		interData: true,
+	}
 	distinctCountMergeJobConfig = distinctCountJobConfigType{
 		lgK:                   12,
 		numTrials:             100,

--- a/go/configs.go
+++ b/go/configs.go
@@ -17,9 +17,9 @@
 
 package main
 
-import "github.com/apache/datasketches-go/hll"
-
 type distinctCountJobConfigType struct {
+	lgK int // lgK of distinct count sketch
+
 	lgMinU int // The starting # of uniques that is printed at the end.
 	lgMaxU int // How high the # uniques go
 	UPPO   int // The horizontal x-resolution of trials points
@@ -31,7 +31,9 @@ type distinctCountJobConfigType struct {
 	lgQK      int  // size of quantiles sketch
 	interData bool // intermediate data
 
-	runner DistinctCountAccuracyProfileRunner
+	numTrials             int
+	numSketches           int
+	distinctKeysPerSketch int
 }
 
 var (
@@ -46,7 +48,11 @@ var (
 
 		lgQK:      12,
 		interData: true,
-
-		runner: NewHllSketchAccuracyRunner(4 /* lgK */, hll.TgtHllTypeHll8 /* tgtType */),
+	}
+	distinctCountMergeJobConfig = distinctCountJobConfigType{
+		lgK:                   12,
+		numTrials:             100,
+		numSketches:           8192,
+		distinctKeysPerSketch: 32768,
 	}
 )

--- a/go/distinct_count_bounds_accuracy_profile.go
+++ b/go/distinct_count_bounds_accuracy_profile.go
@@ -133,7 +133,7 @@ func (d *DistinctCountBoundsAccuracyProfile) process(cumTrials int, sb *strings.
 		sb.WriteString(fmt.Sprintf("%f", relLUb2))
 		sb.WriteString("\t")
 		sb.WriteString(fmt.Sprintf("%f", relLUb3))
-		sb.WriteString("\t")
+		sb.WriteString("\n")
 
 	}
 }

--- a/go/distinct_count_bounds_accuracy_profile.go
+++ b/go/distinct_count_bounds_accuracy_profile.go
@@ -116,23 +116,23 @@ func (d *DistinctCountBoundsAccuracyProfile) process(cumTrials int, sb *strings.
 		// Quantiles
 		quants, _ := q.qsk.GetQuantiles(GAUSSIANS_3SD, true)
 		for i := 0; i < len(quants); i++ {
-			sb.WriteString(fmt.Sprintf("%f", quants[i]/float64(trueUniques)-1.0))
+			sb.WriteString(fmt.Sprintf("%e", quants[i]/float64(trueUniques)-1.0))
 			sb.WriteString("\t")
 		}
 
 		// Bound averages
-		sb.WriteString(fmt.Sprintf("%f", relLb3))
+		sb.WriteString(fmt.Sprintf("%e", relLb3))
 		sb.WriteString("\t")
-		sb.WriteString(fmt.Sprintf("%f", relLb2))
+		sb.WriteString(fmt.Sprintf("%e", relLb2))
 		sb.WriteString("\t")
-		sb.WriteString(fmt.Sprintf("%f", relLb1))
+		sb.WriteString(fmt.Sprintf("%e", relLb1))
 		sb.WriteString("\t")
 
-		sb.WriteString(fmt.Sprintf("%f", relLUb1))
+		sb.WriteString(fmt.Sprintf("%e", relLUb1))
 		sb.WriteString("\t")
-		sb.WriteString(fmt.Sprintf("%f", relLUb2))
+		sb.WriteString(fmt.Sprintf("%e", relLUb2))
 		sb.WriteString("\t")
-		sb.WriteString(fmt.Sprintf("%f", relLUb3))
+		sb.WriteString(fmt.Sprintf("%e", relLUb3))
 		sb.WriteString("\n")
 
 	}

--- a/go/distinct_count_bounds_accuracy_profile.go
+++ b/go/distinct_count_bounds_accuracy_profile.go
@@ -18,28 +18,27 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"time"
 )
 
-type DistinctCountAccuracyProfile struct {
+type DistinctCountBoundsAccuracyProfile struct {
 	config    distinctCountJobConfigType
 	runner    DistinctCountAccuracyProfileRunner
 	stats     []baseAccuracyStats
 	startTime int64
 }
 
-func NewDistinctCountAccuracyProfile(config distinctCountJobConfigType, runner DistinctCountAccuracyProfileRunner) *DistinctCountAccuracyProfile {
-	return &DistinctCountAccuracyProfile{
+func NewDistinctCountBoundsAccuracyProfile(config distinctCountJobConfigType, runner DistinctCountAccuracyProfileRunner) *DistinctCountBoundsAccuracyProfile {
+	return &DistinctCountBoundsAccuracyProfile{
 		config:    config,
 		runner:    runner,
-		stats:     buildLog2AccuracyStatsArray(config.lgMinU, config.lgMaxU, config.UPPO, config.lgQK),
+		stats:     buildLog2BoundsAccuracyStatsArray(config.lgMinU, config.lgMaxU, config.UPPO, config.lgQK),
 		startTime: time.Now().UnixMilli(),
 	}
 }
 
-func (d *DistinctCountAccuracyProfile) run() {
+func (d *DistinctCountBoundsAccuracyProfile) run() {
 	minT := 1 << d.config.lgMinT
 	maxT := 1 << d.config.lgMaxT
 	maxU := 1 << d.config.lgMaxU
@@ -93,63 +92,59 @@ func (d *DistinctCountAccuracyProfile) run() {
 	}
 }
 
-func (d *DistinctCountAccuracyProfile) process(cumTrials int, sb *strings.Builder) {
+func (d *DistinctCountBoundsAccuracyProfile) process(cumTrials int, sb *strings.Builder) {
 	points := len(d.stats)
 	for pt := 0; pt < points; pt++ {
-		q := d.stats[pt].(*accuracyStats)
+		q := d.stats[pt].(*boundsAccuracyStats)
 
 		trueUniques := q.trueValue
+		relLb3 := q.sumLB3/float64(cumTrials)/float64(trueUniques) - 1.0
+		relLb2 := q.sumLB2/float64(cumTrials)/float64(trueUniques) - 1.0
+		relLb1 := q.sumLB1/float64(cumTrials)/float64(trueUniques) - 1.0
 
-		meanEst := q.sumEst / float64(cumTrials)
-		meanRelErr := q.sumRelErr / float64(cumTrials)
-		meanSqErr := q.sumSqRelErr / float64(cumTrials)
-		normMeanSqErr := meanSqErr / (float64(trueUniques) * float64(trueUniques))
-		rmsRelErr := math.Sqrt(normMeanSqErr)
-		q.rmse = rmsRelErr
+		relLUb1 := q.sumUB1/float64(cumTrials)/float64(trueUniques) - 1.0
+		relLUb2 := q.sumUB2/float64(cumTrials)/float64(trueUniques) - 1.0
+		relLUb3 := q.sumUB3/float64(cumTrials)/float64(trueUniques) - 1.0
 
+		// OUTPUT
 		sb.WriteString(fmt.Sprintf("%d", trueUniques))
 		sb.WriteString("\t")
-
-		sb.WriteString(fmt.Sprintf("%e", meanEst))
-		sb.WriteString("\t")
-
-		sb.WriteString(fmt.Sprintf("%e", meanRelErr))
-		sb.WriteString("\t")
-
-		sb.WriteString(fmt.Sprintf("%e", rmsRelErr))
-		sb.WriteString("\t")
-
+		// TRIALS
 		sb.WriteString(fmt.Sprintf("%d", cumTrials))
 		sb.WriteString("\t")
 
-		quants, _ := q.qsk.GetQuantiles(GAUSSIANS_4SD, true)
+		// Quantiles
+		quants, _ := q.qsk.GetQuantiles(GAUSSIANS_3SD, true)
 		for i := 0; i < len(quants); i++ {
-			sb.WriteString(fmt.Sprintf("%e", float64(quants[i])/(float64(trueUniques))-1.0))
+			sb.WriteString(fmt.Sprintf("%f", quants[i]/float64(trueUniques)-1.0))
 			sb.WriteString("\t")
 		}
 
-		sb.WriteString(fmt.Sprintf("%d", 0))
+		// Bound averages
+		sb.WriteString(fmt.Sprintf("%f", relLb3))
 		sb.WriteString("\t")
-		sb.WriteString(fmt.Sprintf("%d", 0))
+		sb.WriteString(fmt.Sprintf("%f", relLb2))
+		sb.WriteString("\t")
+		sb.WriteString(fmt.Sprintf("%f", relLb1))
+		sb.WriteString("\t")
 
-		sb.WriteString("\n")
+		sb.WriteString(fmt.Sprintf("%f", relLUb1))
+		sb.WriteString("\t")
+		sb.WriteString(fmt.Sprintf("%f", relLUb2))
+		sb.WriteString("\t")
+		sb.WriteString(fmt.Sprintf("%f", relLUb3))
+		sb.WriteString("\t")
+
 	}
 }
 
-func (d *DistinctCountAccuracyProfile) setHeader(sb *strings.Builder) string {
-	sb.WriteString("TrueU")
-	sb.WriteString("\t")
-	sb.WriteString("MeanEst")
-	sb.WriteString("\t")
-	sb.WriteString("MeanRelErr")
-	sb.WriteString("\t")
-	sb.WriteString("RMS_RE")
+func (d *DistinctCountBoundsAccuracyProfile) setHeader(sb *strings.Builder) string {
+	sb.WriteString("InU")
 	sb.WriteString("\t")
 	sb.WriteString("Trials")
 	sb.WriteString("\t")
 	sb.WriteString("Min")
 	sb.WriteString("\t")
-	sb.WriteString("Q(.0000317)")
 	sb.WriteString("\t")
 	sb.WriteString("Q(.00135)")
 	sb.WriteString("\t")
@@ -165,23 +160,30 @@ func (d *DistinctCountAccuracyProfile) setHeader(sb *strings.Builder) string {
 	sb.WriteString("\t")
 	sb.WriteString("Q(.99865)")
 	sb.WriteString("\t")
-	sb.WriteString("Q(.9999683)")
 	sb.WriteString("\t")
 	sb.WriteString("Max")
 	sb.WriteString("\t")
-	sb.WriteString("Bytes")
+	sb.WriteString("avgLB3")
 	sb.WriteString("\t")
-	sb.WriteString("ReMerit")
+	sb.WriteString("avgLB2")
+	sb.WriteString("\t")
+	sb.WriteString("avgLB1")
+	sb.WriteString("\t")
+	sb.WriteString("avgUB1")
+	sb.WriteString("\t")
+	sb.WriteString("avgUB2")
+	sb.WriteString("\t")
+	sb.WriteString("avgUB3")
 	sb.WriteString("\n")
 	return sb.String()
 }
 
-func buildLog2AccuracyStatsArray(lgMin, lgMax, ppo, lgQK int) []baseAccuracyStats {
+func buildLog2BoundsAccuracyStatsArray(lgMin, lgMax, ppo, lgQK int) []baseAccuracyStats {
 	qLen := countPoints(lgMin, lgMax, ppo)
 	qArr := make([]baseAccuracyStats, qLen)
 	p := uint64(1) << lgMin
 	for i := 0; i < qLen; i++ {
-		qArr[i] = newAccuracyStats(1<<lgQK, p)
+		qArr[i] = newBoundsAccuracyStats(1<<lgQK, p)
 		p = pwr2SeriesNext(ppo, p)
 	}
 	return qArr

--- a/go/distinct_count_merge_accuracy_profile.go
+++ b/go/distinct_count_merge_accuracy_profile.go
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main
+
+import (
+	"fmt"
+	"github.com/apache/datasketches-go/hll"
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+type DistinctCountMergeAccuracyProfile struct {
+	config    distinctCountJobConfigType
+	startTime int64
+}
+
+func NewDistinctCountMergeAccuracyProfile(config distinctCountJobConfigType) *DistinctCountMergeAccuracyProfile {
+	return &DistinctCountMergeAccuracyProfile{
+		config:    config,
+		startTime: time.Now().UnixMilli(),
+	}
+}
+
+func (d *DistinctCountMergeAccuracyProfile) run() {
+	key := rand.Int64()
+	trueCount := d.config.numSketches * d.config.distinctKeysPerSketch
+
+	var (
+		sumEstimates                        float64
+		sumOfSquaredDeviationsFromTrueCount float64
+	)
+
+	for t := 0; t < d.config.numTrials; t++ {
+		union, _ := hll.NewUnion(d.config.lgK)
+
+		for s := 0; s < d.config.numSketches; s++ {
+			sk, _ := hll.NewHllSketch(d.config.lgK, hll.TgtHllTypeHll8)
+			for k := 0; k < d.config.distinctKeysPerSketch; k++ {
+				sk.UpdateInt64(key)
+				key += 1
+			}
+			union.UpdateSketch(sk)
+		}
+		skRes, _ := union.GetResult(hll.TgtHllTypeDefault)
+		estimatedCount, _ := skRes.GetEstimate()
+		sumEstimates += estimatedCount
+		sumOfSquaredDeviationsFromTrueCount += (estimatedCount - float64(trueCount)) * (estimatedCount - float64(trueCount))
+	}
+
+	meanEstimate := sumEstimates / float64(d.config.numTrials)
+	meanRelativeError := meanEstimate/float64(trueCount) - 1
+	relativeStandardError := math.Sqrt(sumOfSquaredDeviationsFromTrueCount/float64(d.config.numTrials)) / float64(trueCount)
+
+	fmt.Println(fmt.Sprintf("True count: %d", trueCount))
+	fmt.Println(fmt.Sprintf("Mean Estimate: %f", meanEstimate))
+	fmt.Println(fmt.Sprintf("Mean Relative Error: %f", meanRelativeError))
+	fmt.Println(fmt.Sprintf("Relative Standard Error: %f", relativeStandardError))
+}

--- a/go/distinct_count_utils.go
+++ b/go/distinct_count_utils.go
@@ -14,38 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package main
 
-import (
-	"github.com/apache/datasketches-go/hll"
+type baseAccuracyStats interface {
+}
+
+type DistinctCountAccuracyProfileRunner interface {
+	runTrial(stats []baseAccuracyStats, key uint64) uint64
+}
+
+const (
+	M4SD = 0.0000316712418331 //minus 4 StdDev
+	M3SD = 0.0013498980316301 //minus 3 StdDev
+	M2SD = 0.0227501319481792 //minus 2 StdDev
+	M1SD = 0.1586552539314570 //minus 1 StdDev
+	MED  = 0.5                //median
+	P1SD = 0.8413447460685430 //plus  1 StdDev
+	P2SD = 0.9772498680518210 //plus  2 StdDev
+	P3SD = 0.9986501019683700 //plus  3 StdDev
+	P4SD = 0.9999683287581670 //plus  4 StdDev
 )
 
-type HllSketchAccuracyRunner struct {
-	sketch hll.HllSketch
-}
-
-func NewHllSketchAccuracyRunner(lgK int, tgtType hll.TgtHllType) *HllSketchAccuracyRunner {
-	sketch, _ := hll.NewHllSketch(lgK, tgtType)
-	return &HllSketchAccuracyRunner{
-		sketch: sketch,
-	}
-}
-
-func (h *HllSketchAccuracyRunner) runTrial(stats []*accuracyStats, key uint64) uint64 {
-	h.sketch.Reset()
-
-	lastUniques := uint64(0)
-	for _, stat := range stats {
-		delta := stat.trueValue - lastUniques
-		for u := uint64(0); u < delta; u++ {
-			h.sketch.UpdateUInt64(key)
-			key++
-		}
-		lastUniques += delta
-		est, _ := h.sketch.GetEstimate()
-		stat.update(est)
-	}
-
-	return key
-}
+var (
+	GAUSSIANS_4SD = []float64{0.0, M4SD, M3SD, M2SD, M1SD, MED, P1SD, P2SD, P3SD, P4SD, 1.0}
+	GAUSSIANS_3SD = []float64{0.0, M3SD, M2SD, M1SD, MED, P1SD, P2SD, P3SD, 1.0}
+)

--- a/go/hll_sketch_accuracy_runner.go
+++ b/go/hll_sketch_accuracy_runner.go
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"github.com/apache/datasketches-go/common"
+	"github.com/apache/datasketches-go/hll"
+	"github.com/apache/datasketches-go/kll"
+)
+
+// HllSketchAccuracyRunner is A Runner for HLL tracking accuracyStats
+type HllSketchAccuracyRunner struct {
+	sketch hll.HllSketch
+}
+
+type accuracyStats struct {
+	qsk         *kll.ItemsSketch[float64]
+	sumEst      float64
+	sumRelErr   float64
+	sumSqRelErr float64
+	rmse        float64
+	trueValue   uint64
+	uniques     int
+	bytes       int
+}
+
+func newAccuracyStats(k int, trueValue uint64) *accuracyStats {
+	qsk, _ := kll.NewKllItemsSketch[float64](uint16(k), 8, common.ArrayOfDoublesSerDe{})
+	return &accuracyStats{
+		qsk:       qsk,
+		trueValue: trueValue,
+		uniques:   int(trueValue),
+	}
+}
+
+func (a *accuracyStats) update(est float64) {
+	a.qsk.Update(est)
+	a.sumEst += est
+	a.sumRelErr += est/float64(a.trueValue) - 1.0
+	erro := est - float64(a.trueValue)
+	a.sumSqRelErr += erro * erro
+}
+
+func NewHllSketchAccuracyRunner(lgK int, tgtType hll.TgtHllType) *HllSketchAccuracyRunner {
+	sketch, _ := hll.NewHllSketch(lgK, tgtType)
+	return &HllSketchAccuracyRunner{
+		sketch: sketch,
+	}
+}
+
+func (h *HllSketchAccuracyRunner) runTrial(stats []baseAccuracyStats, key uint64) uint64 {
+	h.sketch.Reset()
+
+	lastUniques := uint64(0)
+	for _, ostat := range stats {
+		stat := ostat.(*accuracyStats)
+		delta := stat.trueValue - lastUniques
+		for u := uint64(0); u < delta; u++ {
+			h.sketch.UpdateUInt64(key)
+			key++
+		}
+		lastUniques += delta
+		est, _ := h.sketch.GetEstimate()
+		stat.update(est)
+	}
+
+	return key
+}

--- a/go/hll_sketch_bounds_accuracy_runner.go
+++ b/go/hll_sketch_bounds_accuracy_runner.go
@@ -80,8 +80,8 @@ func (h *HllSketchBoundsAccuracyRunner) runTrial(stats []baseAccuracyStats, key 
 		stat := ostat.(*boundsAccuracyStats)
 		delta := stat.trueValue - lastUniques
 		for u := uint64(0); u < delta; u++ {
-			h.sketch.UpdateUInt64(key)
 			key++
+			h.sketch.UpdateUInt64(key)
 		}
 		lastUniques += delta
 		est, _ := h.sketch.GetEstimate()

--- a/go/hll_sketch_bounds_accuracy_runner.go
+++ b/go/hll_sketch_bounds_accuracy_runner.go
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"github.com/apache/datasketches-go/common"
+	"github.com/apache/datasketches-go/hll"
+	"github.com/apache/datasketches-go/kll"
+)
+
+// HllSketchBoundsAccuracyRunner is A Runner for HLL tracking boundsAccuracyStats
+type HllSketchBoundsAccuracyRunner struct {
+	sketch hll.HllSketch
+}
+
+type boundsAccuracyStats struct {
+	qsk       *kll.ItemsSketch[float64]
+	sumLB3    float64
+	sumLB2    float64
+	sumLB1    float64
+	sumUB3    float64
+	sumUB2    float64
+	sumUB1    float64
+	trueValue uint64
+}
+
+func newBoundsAccuracyStats(k int, trueValue uint64) *boundsAccuracyStats {
+	qsk, _ := kll.NewKllItemsSketch[float64](uint16(k), 8, common.ArrayOfDoublesSerDe{})
+	return &boundsAccuracyStats{
+		qsk:       qsk,
+		trueValue: trueValue,
+	}
+}
+
+func (a *boundsAccuracyStats) update(
+	est float64,
+	lb3 float64,
+	lb2 float64,
+	lb1 float64,
+	ub1 float64,
+	ub2 float64,
+	ub3 float64,
+) {
+	a.qsk.Update(est)
+	a.sumLB3 += lb3
+	a.sumLB2 += lb2
+	a.sumLB1 += lb1
+	a.sumUB1 += ub1
+	a.sumUB2 += ub2
+	a.sumUB3 += ub3
+}
+
+func NewHllSketchBoundsAccuracyRunner(lgK int, tgtType hll.TgtHllType) *HllSketchBoundsAccuracyRunner {
+	sketch, _ := hll.NewHllSketch(lgK, tgtType)
+	return &HllSketchBoundsAccuracyRunner{
+		sketch: sketch,
+	}
+}
+
+func (h *HllSketchBoundsAccuracyRunner) runTrial(stats []baseAccuracyStats, key uint64) uint64 {
+	h.sketch.Reset()
+
+	lastUniques := uint64(0)
+	for _, ostat := range stats {
+		stat := ostat.(*boundsAccuracyStats)
+		delta := stat.trueValue - lastUniques
+		for u := uint64(0); u < delta; u++ {
+			h.sketch.UpdateUInt64(key)
+			key++
+		}
+		lastUniques += delta
+		est, _ := h.sketch.GetEstimate()
+		lb3, _ := h.sketch.GetLowerBound(3)
+		lb2, _ := h.sketch.GetLowerBound(2)
+		lb1, _ := h.sketch.GetLowerBound(1)
+
+		ub1, _ := h.sketch.GetUpperBound(1)
+		ub2, _ := h.sketch.GetUpperBound(2)
+		ub3, _ := h.sketch.GetUpperBound(3)
+
+		stat.update(est, lb3, lb2, lb1, ub1, ub2, ub3)
+	}
+
+	return key
+}

--- a/go/main.go
+++ b/go/main.go
@@ -30,8 +30,8 @@ var (
 			NewHllSketchAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */),
 		),
 		"distinct_count_bound_accuracy_profile": NewDistinctCountBoundsAccuracyProfile(
-			distinctCountJobConfig,
-			NewHllSketchBoundsAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */),
+			distinctCountBoundsJobConfig,
+			NewHllSketchBoundsAccuracyRunner(distinctCountBoundsJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */),
 		),
 		"distinct_count_merge_accuracy_profile": NewDistinctCountMergeAccuracyProfile(
 			distinctCountMergeJobConfig,

--- a/go/main.go
+++ b/go/main.go
@@ -19,12 +19,23 @@ package main
 
 import (
 	"fmt"
+	"github.com/apache/datasketches-go/hll"
 	"os"
 )
 
 var (
 	jobs = map[string]JobProfile{
-		"distinct_count_accuracy_profile": NewDistinctCountAccuracyProfile(distinctCountJobConfig),
+		"distinct_count_accuracy_profile": NewDistinctCountAccuracyProfile(
+			distinctCountJobConfig,
+			NewHllSketchAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */),
+		),
+		"distinct_count_bound_accuracy_profile": NewDistinctCountBoundsAccuracyProfile(
+			distinctCountJobConfig,
+			NewHllSketchBoundsAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */),
+		),
+		"distinct_count_merge_accuracy_profile": NewDistinctCountMergeAccuracyProfile(
+			distinctCountMergeJobConfig,
+		),
 	}
 )
 
@@ -32,7 +43,7 @@ func usage() {
 	fmt.Println("Usage: go run main.go <job>")
 	fmt.Println("Available jobs:")
 	for job := range jobs {
-		fmt.Println(job)
+		fmt.Println(fmt.Sprintf("\t%s", job))
 	}
 	os.Exit(1)
 }

--- a/go/main_test.go
+++ b/go/main_test.go
@@ -18,10 +18,18 @@
 package main
 
 import (
+	"github.com/apache/datasketches-go/hll"
 	"testing"
 )
 
 func TestHllSketchAccuracyRunner(t *testing.T) {
-	runner := NewDistinctCountAccuracyProfile(distinctCountJobConfig)
-	runner.run()
+	runner := NewHllSketchAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */)
+	profile := NewDistinctCountAccuracyProfile(distinctCountJobConfig, runner)
+	profile.run()
+}
+
+func TestHllSketchBoundsAccuracyRunner(t *testing.T) {
+	runner := NewHllSketchBoundsAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */)
+	profile := NewDistinctCountBoundsAccuracyProfile(distinctCountJobConfig, runner)
+	profile.run()
 }

--- a/go/main_test.go
+++ b/go/main_test.go
@@ -18,18 +18,13 @@
 package main
 
 import (
-	"github.com/apache/datasketches-go/hll"
 	"testing"
 )
 
 func TestHllSketchAccuracyRunner(t *testing.T) {
-	runner := NewHllSketchAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */)
-	profile := NewDistinctCountAccuracyProfile(distinctCountJobConfig, runner)
-	profile.run()
+	jobs["distinct_count_accuracy_profile"].run()
 }
 
 func TestHllSketchBoundsAccuracyRunner(t *testing.T) {
-	runner := NewHllSketchBoundsAccuracyRunner(distinctCountJobConfig.lgK, hll.TgtHllTypeHll8 /* tgtType */)
-	profile := NewDistinctCountBoundsAccuracyProfile(distinctCountJobConfig, runner)
-	profile.run()
+	jobs["distinct_count_bound_accuracy_profile"].run()
 }


### PR DESCRIPTION
Add two new profile for HLL (Go)
* distinct_count_bound_accuracy_profile
* distinct_count_merge_accuracy_profile



```
❯ go run . distinct_count_merge_accuracy_profile
True count: 268435456
Mean Estimate: 268155735.491903
Mean Relative Error: -0.001042
Relative Standard Error: 0.015453
```